### PR TITLE
Use 32 bits integers instead of 64

### DIFF
--- a/apps/c++/test_app/src/main.cpp
+++ b/apps/c++/test_app/src/main.cpp
@@ -18,7 +18,7 @@ const int serverPort = 8000;
 
 int main() {
     app().registerHandler(
-        "/", 
+        "/",
         [] (const HttpRequestPtr&, RespCallbackT &&callback) {
             auto resp = HttpResponse::newHttpResponse();
             resp->setBody("C++ test");
@@ -27,7 +27,7 @@ int main() {
         {Get});
 
     app().registerHandler(
-        "/echo/{data}", 
+        "/echo/{data}",
         [] (const HttpRequestPtr&, RespCallbackT &&callback, const std::string& data) {
             auto resp = HttpResponse::newHttpResponse();
             resp->setBody(data);
@@ -36,15 +36,15 @@ int main() {
         {Get});
 
     app().registerHandler(
-        "/getPrimesLessThan/{limit}", 
+        "/getPrimesLessThan/{limit}",
         [] (const HttpRequestPtr&, RespCallbackT &&callback, const std::string& limit) {
             try {
                 auto num_limit = std::stoul(limit);
                 auto primes = primes::get_primes_less_than(num_limit);
 
                 Json::Value root;
-                root["prime_less_than"] = Json::Value::UInt64(num_limit);
-                root["count"] = Json::Value::UInt64(primes.size());
+                root["prime_less_than"] = Json::Value::Int(num_limit);
+                root["count"] = Json::Value::Int(primes.size());
                 root["primes"] = std::move(primes);
 
                 callback(HttpResponse::newHttpJsonResponse(root));
@@ -59,14 +59,14 @@ int main() {
         {Get});
 
     app().registerHandler(
-        "/countPrimesLessThan/{limit}", 
+        "/countPrimesLessThan/{limit}",
         [] (const HttpRequestPtr&, RespCallbackT &&callback, const std::string& limit) {
             try {
                 auto num_limit = std::stoul(limit);
 
                 Json::Value root;
-                root["prime_less_than"] = Json::Value::UInt64(num_limit);
-                root["count"] = Json::Value::UInt64(primes::count_primes_less_than(num_limit));
+                root["prime_less_than"] = Json::Value::Int(num_limit);
+                root["count"] = Json::Value::Int(primes::count_primes_less_than(num_limit));
 
                 callback(HttpResponse::newHttpJsonResponse(root));
             }
@@ -82,4 +82,3 @@ int main() {
     LOG_INFO << "Listening on http://" << serverHost << ':' << serverPort;
     app().addListener(serverHost, serverPort).run();
 }
-

--- a/apps/c++/test_app/src/primes.hpp
+++ b/apps/c++/test_app/src/primes.hpp
@@ -9,38 +9,38 @@
 
 #include <json/json.h>
 
-namespace primes 
+namespace primes
 {
-    inline bool is_prime(std::int64_t num) {
+    inline bool is_prime(std::int32_t num) {
         if (num <= 1) return false;
         if (num == 2) return true;
         if (num % 2 == 0) return false; // the only even prime is 2
 
         // Trial division (https://en.wikipedia.org/wiki/Prime_number#Trial_division)
-        std::int64_t limit = std::sqrt(num);
+        std::int32_t limit = std::sqrt(static_cast<float>(num)); // sqrtf is not available
 
-        for (std::int64_t i=3; i<=limit; i++) {
+        for (std::int32_t i=3; i<=limit; i++) {
             if (num % i == 0) return false;
         }
 
         return true;
     }
 
-    inline Json::Value get_primes_less_than(std::int64_t limit) {
+    inline Json::Value get_primes_less_than(std::int32_t limit) {
         Json::Value result(Json::arrayValue);
 
-        for (std::int64_t i=2; i<limit; i++) { 
+        for (std::int32_t i=2; i<limit; i++) {
             if (is_prime(i))
-                result.append(Json::Value::UInt64(i));
+                result.append(Json::Value::Int(i));
         }
 
         return result;
     }
-    
-    inline std::int64_t count_primes_less_than(std::int64_t limit) {
-        std::int64_t result = 0;
 
-        for (std::int64_t i=2; i<limit; i++) {
+    inline std::int32_t count_primes_less_than(std::int32_t limit) {
+        std::int32_t result = 0;
+
+        for (std::int32_t i=2; i<limit; i++) {
             if (is_prime(i)) result++;
         }
 

--- a/apps/csharp/test_app/src/Controller.cs
+++ b/apps/csharp/test_app/src/Controller.cs
@@ -25,12 +25,12 @@ public class Controller : ControllerBase
     }
 
     [HttpGet("getPrimesLessThan/{limit}")]
-    public IList<long> GetPrimesLessThan(long limit) {
+    public IList<int> GetPrimesLessThan(int limit) {
         return Primes.GetPrimesLessThan(limit);
     }
 
     [HttpGet("countPrimesLessThan/{limit}")]
-    public long CountPrimesLessThan(long limit) {
+    public int CountPrimesLessThan(int limit) {
         return Primes.CountPrimesLessThan(limit);
     }
 }

--- a/apps/csharp/test_app/src/Primes.cs
+++ b/apps/csharp/test_app/src/Primes.cs
@@ -1,5 +1,5 @@
 internal static class Primes {
-    public static bool IsPrime(long num) {
+    public static bool IsPrime(int num) {
         if (num <= 1) return false;
         if (num == 2) return true;
         if (num % 2 == 0) return false; // the only even prime is 2
@@ -7,27 +7,27 @@ internal static class Primes {
         // Trial division (https://en.wikipedia.org/wiki/Prime_number#Trial_division)
         var limit = Math.Sqrt(num);
 
-        for (long i=3; i<=limit; i++) {
+        for (int i=3; i<=limit; i++) {
             if (num % i == 0) return false;
         }
 
         return true;
-    } 
+    }
 
-    public static IList<long> GetPrimesLessThan(long limit) {
-        var result = new List<long>();
+    public static IList<int> GetPrimesLessThan(int limit) {
+        var result = new List<int>();
 
-        for (long i=2; i<limit; i++) {
+        for (int i=2; i<limit; i++) {
             if (IsPrime(i)) result.Add(i);
         }
 
         return result;
     }
 
-    public static long CountPrimesLessThan(long limit) {
-        long result = 0;
+    public static int CountPrimesLessThan(int limit) {
+        int result = 0;
 
-        for (long i=2; i<limit; i++) {
+        for (int i=2; i<limit; i++) {
             if (IsPrime(i)) result++;
         }
 

--- a/apps/java/test_app/src/main/java/com/test_app/Controller.java
+++ b/apps/java/test_app/src/main/java/com/test_app/Controller.java
@@ -25,7 +25,7 @@ class Controller {
     }
 
     @GetMapping("getPrimesLessThan/{limit}")
-    Map<String, Object> getPrimesLessThan(@PathVariable long limit) {
+    Map<String, Object> getPrimesLessThan(@PathVariable int limit) {
         var primes = Primes.getPrimesLessThan(limit);
 
         var result = new LinkedHashMap<String, Object>();
@@ -38,7 +38,7 @@ class Controller {
     }
 
     @GetMapping("countPrimesLessThan/{limit}")
-    Map<String, Object> countPrimesLessThan(@PathVariable long limit) {
+    Map<String, Object> countPrimesLessThan(@PathVariable int limit) {
         var result = new LinkedHashMap<String, Object>();
 
         result.put("prime_less_than", limit);

--- a/apps/java/test_app/src/main/java/com/test_app/Primes.java
+++ b/apps/java/test_app/src/main/java/com/test_app/Primes.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 class Primes {
-    static boolean isPrime(long num) {
+    static boolean isPrime(int num) {
         if (num <= 1) return false;
         if (num == 2) return true;
         if (num % 2 == 0) return false; // the only even prime is 2
@@ -17,27 +17,27 @@ class Primes {
         // Trial division (https://en.wikipedia.org/wiki/Prime_number#Trial_division)
         var limit = Math.sqrt(num);
 
-        for (long i=3; i<=limit; i++) {
+        for (int i=3; i<=limit; i++) {
             if (num % i == 0) return false;
         }
 
         return true;
-    } 
+    }
 
-    static List<Long> getPrimesLessThan(long limit) {
-        var result = new ArrayList<Long>();
+    static List<Integer> getPrimesLessThan(int limit) {
+        var result = new ArrayList<Integer>();
 
-        for (long i=2; i<limit; i++) {
+        for (int i=2; i<limit; i++) {
             if (Primes.isPrime(i)) result.add(i);
         }
 
         return result;
     }
 
-    static long countPrimesLessThan(long limit) {
-        long result = 0;
+    static int countPrimesLessThan(int limit) {
+        int result = 0;
 
-        for (long i=2; i<limit; i++) {
+        for (int i=2; i<limit; i++) {
             if (Primes.isPrime(i)) result++;
         }
 

--- a/apps/rust/test_app/src/main.rs
+++ b/apps/rust/test_app/src/main.rs
@@ -19,7 +19,7 @@ fn echo(data: &str) -> &str {
 }
 
 #[get("/getPrimesLessThan/<limit>")]
-fn get_primes_less_than(limit: i64) -> String {
+fn get_primes_less_than(limit: i32) -> String {
     let primes = primes::get_primes_less_than(limit);
 
     let response = object! {
@@ -32,7 +32,7 @@ fn get_primes_less_than(limit: i64) -> String {
 }
 
 #[get("/countPrimesLessThan/<limit>")]
-fn count_primes_less_than(limit: i64) -> String {
+fn count_primes_less_than(limit: i32) -> String {
     let response = object! {
         primes_less_than: limit,
         count: primes::count_primes_less_than(limit)

--- a/apps/rust/test_app/src/primes.rs
+++ b/apps/rust/test_app/src/primes.rs
@@ -6,11 +6,11 @@
 // Inline attributes are just to be on pair with C++ implementation (see primes.hpp)
 
 #[inline]
-fn is_prime(n: i64) -> bool {
+fn is_prime(n: i32) -> bool {
     if n <= 1 {
         return false;
     }
-    
+
     if n == 2 {
         return true;
     }
@@ -18,10 +18,10 @@ fn is_prime(n: i64) -> bool {
     // the only even prime is 2
     if n % 2 == 0 {
         return false;
-    } 
+    }
 
     // Trial division (https://en.wikipedia.org/wiki/Prime_number#Trial_division)
-    let limit = (n as f64).sqrt() as i64 + 1;
+    let limit = (n as f32).sqrt() as i32 + 1;
 
     for i in 3..limit {
         if n % i == 0 {
@@ -33,8 +33,8 @@ fn is_prime(n: i64) -> bool {
 }
 
 #[inline]
-pub fn get_primes_less_than(limit: i64) -> Vec<i64> {
-    let mut result: Vec<i64> = Vec::new();
+pub fn get_primes_less_than(limit: i32) -> Vec<i32> {
+    let mut result: Vec<i32> = Vec::new();
 
     for i in 2..limit {
         if is_prime(i) {
@@ -46,8 +46,8 @@ pub fn get_primes_less_than(limit: i64) -> Vec<i64> {
 }
 
 #[inline]
-pub fn count_primes_less_than(limit: i64) -> i64 {
-    let mut result: i64 = 0;
+pub fn count_primes_less_than(limit: i32) -> i32 {
+    let mut result: i32 = 0;
 
     for i in 2..limit {
         if is_prime(i) {


### PR DESCRIPTION
In order to be fair with all languages, 32 bits integers are used wherever it can